### PR TITLE
Update CSP JSON files to add zero entries for soil testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CSP JSON data files. [#61](https://github.com/policy-design-lab/pdl-api/issues/61)
 - Update EQIP JSON data files. [#53](https://github.com/policy-design-lab/pdl-api/issues/53)
 
+## Fixed
+- CSP JSON file by adding zero entries for soil testing. [#69](https://github.com/policy-design-lab/pdl-api/issues/69)
+
 ## [0.1.0] - 2023-04-18
 
 ### Added

--- a/app/controllers/data/conservation/csp/csp_practice_categories_data.json
+++ b/app/controllers/data/conservation/csp/csp_practice_categories_data.json
@@ -42,6 +42,11 @@
                     "practiceCategoryName": "Bundles",
                     "totalPaymentInDollars": 11125700.0,
                     "totalPaymentInPercentage": 1.3
+                },
+                {
+                    "practiceCategoryName": "Soil testing",
+                    "totalPaymentInDollars": 0.0,
+                    "totalPaymentInPercentage": 0.0
                 }
             ],
             "totalPaymentInDollars": 858650262.0,

--- a/app/controllers/data/conservation/csp/csp_state_distribution_data.json
+++ b/app/controllers/data/conservation/csp/csp_state_distribution_data.json
@@ -487,12 +487,12 @@
                             "paymentInPercentageWithinState": 0.06
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -1034,12 +1034,12 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -1471,12 +1471,12 @@
                             "paymentInPercentageWithinState": 0.59
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -1579,12 +1579,12 @@
                             "paymentInPercentageWithinState": 0.55
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -2127,12 +2127,12 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -2236,12 +2236,12 @@
                             "paymentInPercentageWithinState": 0.23
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -2670,12 +2670,12 @@
                             "paymentInPercentageWithinState": 0.15
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -2996,12 +2996,12 @@
                             "paymentInPercentageWithinState": 0.14
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3104,12 +3104,12 @@
                             "paymentInPercentageWithinState": 0.24
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3322,12 +3322,12 @@
                             "paymentInPercentageWithinState": 0.07
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3431,12 +3431,12 @@
                             "paymentInPercentageWithinState": 0.08
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3539,12 +3539,12 @@
                             "paymentInPercentageWithinState": 0.04
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3757,12 +3757,12 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3865,12 +3865,12 @@
                             "paymentInPercentageWithinState": 0.13
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -3974,12 +3974,12 @@
                             "paymentInPercentageWithinState": 0.02
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4123,12 +4123,12 @@
                             "paymentInPercentageWithinState": 0.39
                         },
                         {
-                            "practiceCategoryName": "Non-industrial private forestland",
+                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Pastured cropland",
+                            "practiceCategoryName": "Non-industrial private forestland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4190,12 +4190,12 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4401,17 +4401,17 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Bundles",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
                             "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
                             "practiceCategoryName": "Soil testing",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4446,12 +4446,12 @@
                             "paymentInPercentageWithinState": 1.03
                         },
                         {
-                            "practiceCategoryName": "Rangeland",
+                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Pastured cropland",
+                            "practiceCategoryName": "Rangeland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4513,12 +4513,12 @@
                             "paymentInPercentageWithinState": 0.16
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4615,17 +4615,17 @@
                             "paymentInPercentageWithinState": 0.13
                         },
                         {
-                            "practiceCategoryName": "Bundles",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
                             "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
                             "practiceCategoryName": "Soil testing",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4710,12 +4710,7 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Forest management",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -4725,12 +4720,17 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
+                            "practiceCategoryName": "Bundles",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
                             "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Forest management",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -4827,12 +4827,12 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil remediation",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil remediation",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -4934,12 +4934,12 @@
                             "paymentInPercentageWithinState": 0.03
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil remediation",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil remediation",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5035,7 +5035,7 @@
                             "paymentInPercentageWithinState": 0.04
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5045,7 +5045,7 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Other improvement",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5147,17 +5147,17 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Bundles",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
                             "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
                             "practiceCategoryName": "Soil testing",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5260,12 +5260,12 @@
                             "paymentInPercentageWithinState": 0.19
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5300,12 +5300,12 @@
                             "paymentInPercentageWithinState": 2.17
                         },
                         {
-                            "practiceCategoryName": "Rangeland",
+                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Pastured cropland",
+                            "practiceCategoryName": "Rangeland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5343,17 +5343,7 @@
                             "paymentInPercentageWithinState": 0.01
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
-                            "practiceCategoryName": "Bundles",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
-                            "practiceCategoryName": "Land management",
+                            "practiceCategoryName": "Structural",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5363,12 +5353,22 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
+                            "practiceCategoryName": "Bundles",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
                             "practiceCategoryName": "Other improvement",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Structural",
+                            "practiceCategoryName": "Soil testing",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
+                            "practiceCategoryName": "Land management",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5397,17 +5397,17 @@
                             "paymentInPercentageWithinState": 8.79
                         },
                         {
+                            "practiceCategoryName": "Pastured cropland",
+                            "paymentInDollars": 0.0,
+                            "paymentInPercentageWithinState": 0.0
+                        },
+                        {
                             "practiceCategoryName": "Rangeland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
                             "practiceCategoryName": "Pastureland",
-                            "paymentInDollars": 0.0,
-                            "paymentInPercentageWithinState": 0.0
-                        },
-                        {
-                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5469,12 +5469,12 @@
                             "paymentInPercentageWithinState": 0.04
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5503,7 +5503,7 @@
                             "paymentInPercentageWithinState": 7.55
                         },
                         {
-                            "practiceCategoryName": "Non-industrial private forestland",
+                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5513,7 +5513,7 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Pastured cropland",
+                            "practiceCategoryName": "Non-industrial private forestland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }
@@ -5569,12 +5569,12 @@
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Bundles",
+                            "practiceCategoryName": "Soil testing",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Soil testing",
+                            "practiceCategoryName": "Bundles",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
@@ -5614,12 +5614,12 @@
                             "paymentInPercentageWithinState": 4.1
                         },
                         {
-                            "practiceCategoryName": "Rangeland",
+                            "practiceCategoryName": "Pastured cropland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         },
                         {
-                            "practiceCategoryName": "Pastured cropland",
+                            "practiceCategoryName": "Rangeland",
                             "paymentInDollars": 0.0,
                             "paymentInPercentageWithinState": 0.0
                         }


### PR DESCRIPTION
This PR fixes a minor issue: zero entries are now added to the practice categories JSON file when actual data is not present. The changes in csp_state_distribution_data.json probably result from re-sorting after adding zero entries for soil testing.