### PR TITLE
Fix error due to previous SNAP program ID being used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Error when calling GET states endpoint after recent change. [#228](https://github.com/policy-design-lab/pdl-api/issues/228)
+- Error due to the previous SNAP program ID being used. [#230](https://github.com/policy-design-lab/pdl-api/issues/230) 
 
 ## [0.15.0] - 2024-07-19
 

--- a/app/controllers/pdl.py
+++ b/app/controllers/pdl.py
@@ -533,7 +533,7 @@ def titles_title_xi_programs_crop_insurance_summary_search():
 
 # /pdl/titles/title-iv/programs/snap/state-distribution
 def titles_title_iv_programs_snap_state_distribution_search():
-    program_id = 106
+    program_id = 111
     start_year = 2018
     end_year = 2022
     endpoint_response = generate_title_iv_state_distribution_response(program_id, start_year, end_year)


### PR DESCRIPTION
This PR fixes an error that was introduced recently. During the recent data ingestion of EQIP and CSP, SNAP's program ID changed in the database, as the IDs were generated sequentially. This is a temporary fix, and we need to change the way we are using program ID's in the API. I will create another issue for that.