### PR TITLE
Removed programName from crop insurance state-distribute output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CRP endpoints to use data from the database. [#237](https://github.com/policy-design-lab/pdl-api/issues/237)
 - ACEP endpoints to use data from the database. [#239](https://github.com/policy-design-lab/pdl-api/issues/239)
 - RCPP endpoints to use data from the database. [#241](https://github.com/policy-design-lab/pdl-api/issues/241)
+- PrgramName attribute has been removed from crop insurance's state-distibution output [#255](https://github.com/polciy-design-lab/pdl-api/issues/255)
 
 ## [0.17.0] - 2024-08-28
 

--- a/app/controllers/pdl.py
+++ b/app/controllers/pdl.py
@@ -2076,7 +2076,6 @@ def generate_title_xi_state_distribution_response(program_id, start_year, end_ye
 
     state_aggregate_dict = defaultdict(lambda: {
         'state': '',
-        'programName': TITLE_XI_CROP_INSURANCE_PROGRAM_NAME,
         'totalIndemnitiesInDollars': 0,
         'totalPremiumInDollars': 0,
         'totalPremiumSubsidyInDollars': 0,


### PR DESCRIPTION
programName attribute has been removed from the attribute of state-distribution in crop-insurance. So the result is like

{
  "2018-2022": [
    {
      "state": "TX",
      "totalIndemnitiesInDollars": 10192200379,
      "totalPremiumInDollars": 6715854749,
      "totalPremiumSubsidyInDollars": 4527376715,
      "totalFarmerPaidPremiumInDollars": 2188478034,
      "totalNetFarmerBenefitInDollars": 8003722345,
      "totalPoliciesEarningPremium": 368335,
      "averageLiabilitiesInDollars": 5808509412.2,
      "averageInsuredAreaInAcres": 43828206.2,
      "lossRatio": 1.518,
      "subPrograms": []
    },