### PR TITLE
263 feature add endpoint to return practice codes and names for title 2 programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Endpoints to get practice codes and names for EQIP and CSP. [#263](https://github.com/policy-design-lab/pdl-api/issues/263)
+
 ## [0.19.0] - 2024-11-03
 
 ### Changed

--- a/app/controllers/pdl.py
+++ b/app/controllers/pdl.py
@@ -3,7 +3,7 @@ import logging
 import os
 from collections import OrderedDict
 from flask import request
-from sqlalchemy import func, desc, Numeric, BigInteger, Integer, text, distinct, and_
+from sqlalchemy import func, desc, Numeric, BigInteger, Integer, text
 
 import app.utils.jsonutils as jsonutils
 import app.utils.rest_handlers as rs_handlers
@@ -2757,6 +2757,7 @@ def generate_title_ii_practice_names_response(program_id, start_year, end_year):
         )
         .group_by(Payment.year, Payment.practice_code, Practice.name)
         .order_by(Payment.year, Payment.practice_code)
+        .distinct(Payment.year, Payment.practice_code)
     )
 
     # Execute the query

--- a/app/controllers/pdl.py
+++ b/app/controllers/pdl.py
@@ -3,12 +3,13 @@ import logging
 import os
 from collections import OrderedDict
 from flask import request
-from sqlalchemy import func, desc, Numeric, BigInteger, Integer, text
+from sqlalchemy import func, desc, Numeric, BigInteger, Integer, text, distinct, and_
 
 import app.utils.jsonutils as jsonutils
 import app.utils.rest_handlers as rs_handlers
 from app.models.db import Session
 from app.models.payment import Payment
+from app.models.practice import Practice
 from app.models.program import Program
 from app.models.practice_category import PracticeCategory
 from app.models.state import State
@@ -386,6 +387,22 @@ def titles_title_ii_programs_eqip_summary_search():
     return endpoint_response
 
 
+# /pdl/titles/title-ii/programs/eqip/practice-names
+def titles_title_ii_programs_eqip_practice_names_search():
+    program_id = get_program_id(TITLE_II_EQIP_PROGRAM_NAME)
+    if program_id is None:
+        msg = {
+            "reason": "No record for the given program name " + TITLE_II_EQIP_PROGRAM_NAME,
+            "error": "Not found: " + request.url,
+        }
+        logging.error("EQIP: " + json.dumps(msg))
+        return rs_handlers.not_found(msg)
+    start_year = 2018
+    end_year = 2022
+    endpoint_response = generate_title_ii_practice_names_response(program_id, start_year, end_year)
+    return endpoint_response
+
+
 # /pdl/titles/title-ii/programs/eqip-ira/state-distribution
 def titles_title_ii_programs_eqip_ira_state_distribution_search():
     # set the file path
@@ -490,6 +507,22 @@ def titles_title_ii_programs_csp_summary_search():
     start_year = 2018
     end_year = 2022
     endpoint_response = generate_title_ii_summary_response(program_id, start_year, end_year)
+    return endpoint_response
+
+
+# /pdl/titles/title-ii/programs/eqip/practice-names
+def titles_title_ii_programs_csp_practice_names_search():
+    program_id = get_program_id(TITLE_II_CSP_PROGRAM_NAME)
+    if program_id is None:
+        msg = {
+            "reason": "No record for the given program name " + TITLE_II_CSP_PROGRAM_NAME,
+            "error": "Not found: " + request.url,
+        }
+        logging.error("EQIP: " + json.dumps(msg))
+        return rs_handlers.not_found(msg)
+    start_year = 2018
+    end_year = 2022
+    endpoint_response = generate_title_ii_practice_names_response(program_id, start_year, end_year)
     return endpoint_response
 
 
@@ -2703,6 +2736,55 @@ def generate_title_ii_summary_response(program_id, start_year, end_year):
 
     response = {**total_values_dict, "statutes": statutes_list, "subPrograms": sub_programs_list}
     return response
+
+
+def generate_title_ii_practice_names_response(program_id, start_year, end_year):
+
+    session = Session()
+
+    # Construct the query
+    query = (
+        session.query(
+            Payment.practice_code,
+            func.concat(Practice.name, ' (', Payment.practice_code, ')').label('practice_name_with_code'),
+            Payment.year
+        )
+        .join(Practice, Practice.code == Payment.practice_code)
+        .filter(
+            Payment.program_id == program_id,
+            Payment.year.between(start_year, end_year),
+            Payment.practice_code.isnot(None)
+        )
+        .group_by(Payment.year, Payment.practice_code, Practice.name)
+        .order_by(Payment.year, Payment.practice_code)
+    )
+
+    # Execute the query
+    result = query.all()
+
+    # Extract column names
+    column_names = [item['name'] for item in query.statement.column_descriptions]
+
+    # Generate result dictionary
+    practice_names_response = dict()
+    practice_names_for_start_to_end_year = dict()
+
+    for row in result:
+        row_dict = dict(zip(column_names, row))
+
+        if str(row_dict["year"]) not in practice_names_response:
+            practice_names_response[str(row_dict["year"])] = []
+        practice_names_response[str(row_dict["year"])].append(row_dict["practice_name_with_code"])
+
+        practice_names_for_start_to_end_year[row_dict["practice_code"]] = row_dict["practice_name_with_code"]
+
+    # Sort practice_names_for_start_to_end_year by practice code
+    practice_names_for_start_to_end_year = dict(sorted(practice_names_for_start_to_end_year.items(), key=lambda item: item[0]))
+
+    # Add the list of practice names for the entire period
+    practice_names_response[str(start_year) + "-" + str(end_year)] = list(practice_names_for_start_to_end_year.values())
+
+    return practice_names_response
 
 
 def generate_title_xi_summary_response(program_id, start_year, end_year):

--- a/app/models/practice.py
+++ b/app/models/practice.py
@@ -1,0 +1,21 @@
+from app.models.db import db
+
+
+class Practice(db.Model):
+    __tablename__ = 'practices'
+    __table_args__ = {"schema": "pdl"}
+
+    code = db.Column(db.String(), primary_key=True)
+    name = db.Column(db.String())
+    display_name = db.Column(db.String())
+    source = db.Column(db.String())
+
+    def __init__(self, code, name, display_name, source):
+        self.code = code
+        self.name = name
+        self.display_name = display_name
+        self.source = source
+
+    def __repr__(self):
+        return 'Practice(code=%s, name=%s, display_name=%s, source=%s)' % (
+            self.code, self.name, self.display_name, self.source)

--- a/app/pdl.yaml
+++ b/app/pdl.yaml
@@ -431,6 +431,26 @@ paths:
           description: Unauthorized
         500:
           description: Internal error
+  /pdl/titles/title-ii/programs/eqip/practice-names:
+    get:
+      tags:
+        - "Title II: Conservation - EQIP (Environmental Quality Incentives Program)"
+      summary: Gets the Title II EQIP list of all practice names for the given start to end year duration.
+      description: |
+        Returns the Title II EQIP list of all practice names for the given start to end year duration.
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          description: Bad request
+        401:
+          description: Unauthorized
+        500:
+          description: Internal error
   /pdl/titles/title-ii/programs/eqip-ira/state-distribution:
     get:
       tags:
@@ -571,6 +591,27 @@ paths:
           description: Unauthorized
         500:
           description: Internal error
+  /pdl/titles/title-ii/programs/csp/practice-names:
+    get:
+      tags:
+        - "Title II: Conservation - CSP (Conservation Stewardship Program)"
+      summary: Gets the Title II CSP list of all practice names for the given start to end year duration.
+      description: |
+        Returns the Title II CSP list of all practice names for the given start to end year duration.
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          description: Bad request
+        401:
+          description: Unauthorized
+        500:
+          description: Internal error
+
   /pdl/titles/title-ii/programs/csp-ira/state-distribution:
     get:
       tags:


### PR DESCRIPTION
This PR adds two new endpoints to get list of practice codes and names. This is currently deployed on the development instance:

1. GET https://policydesignlab-dev.ncsa.illinois.edu/pdl/titles/title-ii/programs/eqip/practice-names
2. GET https://policydesignlab-dev.ncsa.illinois.edu/pdl/titles/title-ii/programs/csp/practice-names