### PR TITLE
285 feature add feature to specify running port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Change house api path. [#295](https://github.com/policy-design-lab/pdl-api/issues/295)
+- Add feature to specify running port. [285](https://github.com/policy-design-lab/pdl-api/issues/285)
 
 ## [0.21.0] - 2024-12-10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV DB_HOST=localhost \
     DB_NAME=pdl \
     DB_USERNAME=user \
     DB_PASSWORD=password \
+    API_PORT=5000 \
     WORKER=4
 
 WORKDIR /usr/src/pdl-api/app

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Create the PDL API Docker image and run the Docker container:
       docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -e API_PORT=port -p port:port pdl/pdl-api 
 
 If the API_PORT is not specify, port is default to 5000:
-      docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -p 5000:5000 pdl/pdl
+      `docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -p 5000:5000 pdl/pdl`
 
 Now you can view the API at http://localhost/pdl/
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Create the PDL API Docker image and run the Docker container:
       docker build -t pdl/pdl-api .
       docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -e API_PORT=port -p port:port pdl/pdl-api 
 
+If the API_PORT is not specify, port is default to 5000:
+      docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -p 5000:5000 pdl/pdl
+
 Now you can view the API at http://localhost/pdl/
 
 For swagger doc, go to http://localhost/ui

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Set variables:
       DB_PORT=5432
       DB_NAME=pdl
       DB_USERNAME=username
-      DB_PASSWORD=password`
+      DB_PASSWORD=password
+      API_PORT=API port
 
 Change directory into pdl-api/app 
 `python main.py`

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ Set variables:
       DB_NAME=pdl
       DB_USERNAME=username
       DB_PASSWORD=password
-      API_PORT=API port
+      API_PORT=API port, default 5000 if not set
 
 Change directory into pdl-api/app 
 `python main.py`
 
-Now you can view the API at http://localhost:5000/pdl/
+Now you can view the API at http://localhost:{API_PORT}/pdl/
 
-For swagger doc, go to http://localhost:5000/ui
+For swagger doc, go to http://localhost:{API_PORT}/ui
 
 ### Using Docker
 Create the PDL API Docker image and run the Docker container:
         
       docker build -t pdl/pdl-api .
-      docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -p 80:5000 pdl/pdl-api 
+      docker run -e DB_HOST=db_host -e DB_PORT=5432 -e DB_NAME=pdl -e DB_USERNAME=username -e DB_PASSWORD=password -e API_PORT=port -p port:port pdl/pdl-api 
 
 Now you can view the API at http://localhost/pdl/
 

--- a/app/controllers/configs.py
+++ b/app/controllers/configs.py
@@ -24,3 +24,7 @@ class Config:
     DB_NAME = os.getenv('DB_NAME')
     DB_USERNAME = os.getenv('DB_USERNAME')
     DB_PASSWORD = os.getenv('DB_PASSWORD')
+
+    # If API_PORT is not set or is empty (null), default to 5000
+    api_port_env = os.environ.get('API_PORT')
+    API_PORT = int(api_port_env) if api_port_env else 5000

--- a/app/controllers/configs.py
+++ b/app/controllers/configs.py
@@ -25,6 +25,5 @@ class Config:
     DB_USERNAME = os.getenv('DB_USERNAME')
     DB_PASSWORD = os.getenv('DB_PASSWORD')
 
-    # If API_PORT is not set or is empty (null), default to 5000
-    api_port_env = os.environ.get('API_PORT')
-    API_PORT = int(api_port_env) if api_port_env else 5000
+    # API port, default to 5000
+    API_PORT = int(os.getenv('API_PORT', '5000'))

--- a/app/controllers/gunicorn_config.py
+++ b/app/controllers/gunicorn_config.py
@@ -1,7 +1,7 @@
 from controllers.configs import Config as cfg
 
 """Gunicorn configuration."""
-bind = '0.0.0.0:5000'
+bind = f'0.0.0.0:{cfg.API_PORT}'
 
 workers = cfg.WORKER
 worker_class = 'gevent'

--- a/app/main.py
+++ b/app/main.py
@@ -39,4 +39,4 @@ db.init_app(app)
 CORS(app)
 
 if __name__ == '__main__':
-    app.run(port=5000, host=None, debug=debug)
+    app.run(port=cfg.API_PORT, host=None, debug=debug)


### PR DESCRIPTION
For testing, please follow the steps in README.

There are several testing cases:
- Add `API_PORT=5001` in .env
- No `API_PORT` in .env
all these three cases should work unless the port has been taken by other programs.

For Docker, build the container first then run the command in README for testing.